### PR TITLE
fix(docker): correct docker compose setup for MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ MYSQL_ROOT_PASSWORD=
 MYSQL_DATABASE=
 MYSQL_USER=
 MYSQL_PASSWORD=
-MYSQL_HOST=
+MYSQL_HOST= # Use 'db' for Docker Compose setup
 MYSQL_PORT=
 
 # Swagger UI and Redoc

--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ cp .env.example .env
 
 > Note: Make sure to correctly configure your variables before building the container.
 
+## Local Development with Docker Compose
+
+To set up your local development environment using Docker Compose, follow these steps:
+
+1.  **Copy the environment file:**
+    If you haven't already, copy the example environment file to a new `.env` file:
+    ```bash
+    cp .env.example .env
+    ```
+
+2.  **Configure your environment variables:**
+    Open the `.env` file and fill in the required environment variables. Pay special attention to the MySQL variables:
+    *   `MYSQL_ROOT_PASSWORD`: Set a strong password for the root user of the MySQL database.
+    *   `MYSQL_DATABASE`: Specify the name of the database to be created.
+    *   `MYSQL_USER`: Define a username for the application to connect to the database.
+    *   `MYSQL_PASSWORD`: Set a password for the application user.
+    *   `MYSQL_HOST`: This should be set to `db`. This is the service name defined in `docker-compose.yml` and will be used by the `web` service to connect to the database container.
+    *   `MYSQL_PORT`: This should be `3306`, which is the default MySQL port.
+
+3.  **Start the services:**
+    Once your `.env` file is configured, you can start all the services (including the web application and the database) using the following command:
+    ```bash
+    docker-compose up --build
+    ```
+    The `--build` flag ensures that Docker rebuilds your images if there have been any changes to your `Dockerfile` or application code. The first time you run this, it might take a few minutes as Docker downloads the necessary images.
+
 ## 🐳 Docker
 
 Build your container; it will take time the first time, as Docker needs to download all dependencies and build the image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,18 @@ services:
     env_file:
       - .env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
-    image: mysql:8.0.42
+    image: mysql:8.0
     container_name: mysql_db
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-P", "3306", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
This commit addresses issues with the Docker Compose configuration for MySQL:

- Updated `mysql` image from `8.0.42` to `8.0` in `docker-compose.yml` for better maintainability.
- Added a healthcheck to the `db` service in `docker-compose.yml` to ensure MySQL is fully ready before other services attempt to connect. The healthcheck uses `mysqladmin ping`.
- Modified the `web` service in `docker-compose.yml` to use `condition: service_healthy` in its `depends_on` clause for the `db` service. This ensures the Django application waits for MySQL to be healthy.
- Verified Django database settings in `config/settings/base.py` are correctly configured to use environment variables and connect to the `db` service on port `3306`. No changes were needed.
- Updated `.env.example` to add a comment clarifying that `MYSQL_HOST` should be set to `db` when using Docker Compose.
- Verified `config/entrypoint.sh`. No changes were needed as the Docker Compose healthcheck is the preferred method for handling service readiness.
- Added a "Local Development with Docker Compose" section to `README.md` with instructions on creating and configuring the `.env` file and running the services.

These changes ensure a more robust and reliable startup sequence for the application when using Docker Compose with MySQL.